### PR TITLE
More exchange and queue settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 node_modules/
 dist
+index.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+# source
+lib
+index.ts
+package-lock.json
+.eslintrc.js
+tsconfig.json
+tsconfig.build.json
+.prettierrc
+.prettierrc
+.commitlintrc.json

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,9 +1,9 @@
 {
   "git": {
-    "requireCleanWorkingDir": false
+    "requireCleanWorkingDir": true
   },
   "github": {
-    "release": false
+    "release": true
   },
   "npm": {
     "publish": false

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Enrique Carpintero
+Copyright (c) 2021 Enrique Carpintero
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,31 @@
 # NestJS-AMQP
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/EnriqCG/nestjs-amqplib/LICENSE.md)
+<p align="center">
 
-AMQP module for NestJS with decorator support
+  <a href="https://github.com/EnriqCG/nestjs-amqplib/LICENSE.md">
+    <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg">
+  </a>
+  <a href="https://www.npmjs.com/package/@enriqcg/nestjs-amqp">
+    <img alt="NPM Pulls" src="https://img.shields.io/npm/dm/@enriqcg/nestjs-amqp?label=NPM%20Pulls">
+  </a>
+  <a href="https://github.com/EnriqCG/nestjs-amqp/releases">
+    <img alt="GitHub release (latest by date)" src="https://img.shields.io/github/v/release/enriqcg/nestjs-amqp">
+  </a>
+
+  <a href="https://github.com/EnriqCG/nestjs-amqp/tags">
+    <img alt="GitHub tag (latest by date)" src="https://img.shields.io/github/v/tag/enriqcg/nestjs-amqp">
+  </a>
+</p>
+
+AMQP module for NestJS with decorator support.
+
+## Note
+
+This project is still a work-in-progress and is being **actively developed**. Issues and PRs are welcome!
+
+**Please check the [v1.0 milestone]((https://github.com/EnriqCG/nestjs-amqp/milestone/1))** for features targeted for the first stable release.
+
+***
 
 This module injects a channel from [amqplib](https://github.com/squaremo/amqp.node). Please check the [Channel](https://www.squaremobius.net/amqp.node/channel_api.html) documentation for extra insight on how to publish messages.
 
@@ -22,13 +45,23 @@ import { AMQPModule } from '@enriqcg/nestjs-amqp'
 
 @Module({
   imports: [
-    AMQPModule.forRoot(options),
+    AMQPModule.forRoot({
+      hostname: 'localhost',
+      // queues we use with @Consume will be created if-need-be
+      assertQueues: true,
+      exchange: {
+        name: 'my_exchange',
+        // exchange will not be asserted (if-need-be)
+        assert: false
+      }
+    }),
   ],
 })
 export class AppModule {}
 ```
 
-[AMQPModule options reference](https://github.com/EnriqCG/nestjs-amqp#connection-options)
+### [AMQPModule options reference](#connection-options)
+Also check documentation [here]() on amqplib's Exchange and Queue **assertion**.
 
 ## Publisher
 
@@ -63,12 +96,14 @@ import { Consume } from '@enriqcg/nestjs-amqp'
 
 export class ExampleController {
 
-  @Consume('queue_name')
+  @Consume('queue_name', {
+    noAck: false, // manual consumer acknowledgments
+  })
   handleEvent(content: string) {
     console.log(JSON.parse(content))
     return false // message will not be acked
     return true //message will be acked
-    // no return? message will be acked
+    // no return? -> message will be acked
   }
 }
 ```
@@ -77,19 +112,60 @@ The message content is **decoded** to a string and provided to decorated methods
 
 ### Message Acknowledgment
 
-If automatic acknoledgment is disabled for a queue, to ack a message the decorated method should return **a non false value**. Anything else than a **false** value will acknowledge a message (even void).
+If automatic acknowledgment is disabled for a queue (`noAck = true`), to ack a message, the decorated method should return **a non-false value**. Anything else than a **false** value will acknowledge a message (even void).
 
 ## Connection options
 
-Name | Explanation | Default
---- | --- | ---
-hostname | The host URL for the connection | `localhost`
-port | The port of the AMQP host | `5672`
-name | The name of the connection | `default` or the array key index `[0]`
-protocol | The protocol for the connection | `amqp`
-username | The username for the connection | 
-password | The password for the connection |
-locale | The desired locale for error messages | `en_US`
-frameMax | The size in bytes of the maximum frame allowed over the connection | 0
-heartbeat | The period of the connection heartbeat in seconds | 0
-vhost | What VHost shall be used | `/`
+```typescript
+interface AMQPModuleOptions {
+  /**
+   * The host URL for the connection
+   * 
+   * Default value: 'localhost'
+   */
+  hostname?: string
+  /**
+   * The port of the AMQP host
+   * 
+   * Default value: 5672
+   */
+  port?: number
+  /**
+   * The name of the connection. Only really relevant in multiple
+   * connection contexts
+   * 
+   * Default value: 'default'
+   */
+  name?: string
+  /**
+   * Username used for authenticating against the server
+   * 
+   * Default value: 'guest'
+   */
+  username?: string
+  /**
+   * Password used for authenticating against the server
+   * 
+   * Default value: 'guest'
+   */
+  password?: string
+  /**
+   * The period of the connection heartbeat in seconds
+   * 
+   * Default value: 0
+   */
+  heartbeat?: number
+  /**
+   * What VHost shall be used
+   * 
+   * Default value: '/'
+   */
+  vhost?: string
+}
+```
+
+## License
+
+[MIT License](http://www.opensource.org/licenses/MIT)
+
+Copyright (c) 2021-present, Enrique Carpintero

--- a/README.md
+++ b/README.md
@@ -138,6 +138,38 @@ interface AMQPModuleOptions {
    */
   name?: string
   /**
+   * Definition for the AMQP exchange to use
+   * If empty, queues will be bound to the default exchange ('')
+   * 
+   * Default value: {}
+   */
+  exchange?: {
+    /**
+     * Name of the exchange to bind queues to
+     * 
+     * A value is required
+     */
+    name: string
+    /**
+     * Name of the exchange to bind queues to
+     * 
+     * A value is only required if the exchange is asserted
+     */
+    type?: 'direct' | 'topic' | 'headers' | 'fanout' | 'match'
+    /**
+     * Assert the exchange
+     * 
+     * Default value: false
+     */
+    assert?: boolean
+  }
+  /**
+   * Assert queues defined with the @Consume decorator
+   * 
+   * Default value: 'default'
+   */
+  assertQueues?: boolean
+  /**
    * Username used for authenticating against the server
    * 
    * Default value: 'guest'

--- a/lib/amqp-core.module.ts
+++ b/lib/amqp-core.module.ts
@@ -27,24 +27,22 @@ export class AMQPCoreModule implements OnModuleDestroy {
   }
 
   onModuleDestroy(): void {
-
-    const closeConnection = ({ clients, defaultKey }) => options => {
-      const connectionName = options.name || defaultKey;
-      const client = clients.get(connectionName);
+    const closeConnection = ({ clients, defaultKey }) => (options) => {
+      const connectionName = options.name || defaultKey
+      const client = clients.get(connectionName)
 
       if (client) {
         client.close()
       }
     }
 
-    const amqpClient = this.moduleRef.get<AMQPClient>(AMQP_CLIENT);
-    const closeClientConnection = closeConnection(amqpClient);
+    const amqpClient = this.moduleRef.get<AMQPClient>(AMQP_CLIENT)
+    const closeClientConnection = closeConnection(amqpClient)
 
     if (Array.isArray(this.options)) {
-      this.options.forEach(closeClientConnection);
+      this.options.forEach(closeClientConnection)
     } else {
-      closeClientConnection(this.options);
+      closeClientConnection(this.options)
     }
-
   }
 }

--- a/lib/amqp.interface.ts
+++ b/lib/amqp.interface.ts
@@ -7,7 +7,7 @@ export interface AMQPModuleOptions extends Partial<Options.Connect> {
 }
 
 export interface EventMetadata {
-  eventName: string
+  queueName: string
   callback: any
 }
 

--- a/lib/amqp.interface.ts
+++ b/lib/amqp.interface.ts
@@ -15,4 +15,5 @@ export interface EventMetadata {
 interface AMQPExchange {
   name: string
   type: 'direct' | 'topic' | 'headers' | 'fanout' | 'match'
+  assert?: boolean
 }

--- a/lib/amqp.interface.ts
+++ b/lib/amqp.interface.ts
@@ -6,6 +6,7 @@ export interface AMQPModuleOptions extends Partial<Options.Connect> {
     name: string
     type: string
   }
+  assertQueues?: boolean
 }
 
 export interface EventMetadata {

--- a/lib/amqp.interface.ts
+++ b/lib/amqp.interface.ts
@@ -14,6 +14,6 @@ export interface EventMetadata {
 
 interface AMQPExchange {
   name: string
-  type: 'direct' | 'topic' | 'headers' | 'fanout' | 'match'
+  type?: 'direct' | 'topic' | 'headers' | 'fanout' | 'match'
   assert?: boolean
 }

--- a/lib/amqp.interface.ts
+++ b/lib/amqp.interface.ts
@@ -8,6 +8,7 @@ export interface AMQPModuleOptions extends Partial<Options.Connect> {
 
 export interface EventMetadata {
   queueName: string
+  consumerOptions?: Options.Consume
   callback: any
 }
 

--- a/lib/amqp.interface.ts
+++ b/lib/amqp.interface.ts
@@ -2,14 +2,16 @@ import { Options } from 'amqplib'
 
 export interface AMQPModuleOptions extends Partial<Options.Connect> {
   name?: string
-  exchange?: {
-    name: string
-    type: string
-  }
   assertQueues?: boolean
+  exchange?: AMQPExchange
 }
 
 export interface EventMetadata {
   eventName: string
   callback: any
+}
+
+interface AMQPExchange {
+  name: string
+  type: 'direct' | 'topic' | 'headers' | 'fanout' | 'match'
 }

--- a/lib/amqp.module.ts
+++ b/lib/amqp.module.ts
@@ -32,7 +32,7 @@ export class AMQPModule implements OnModuleInit {
       options: this.amqpService.getConnectionOptions(),
     }
 
-    if (options.exchange) {
+    if (options.exchange && options.exchange.assert) {
       amqp.assertExchange(options.exchange.name, options.exchange.type)
     }
 

--- a/lib/amqp.module.ts
+++ b/lib/amqp.module.ts
@@ -47,10 +47,10 @@ export class AMQPModule implements OnModuleInit {
         const handlers: EventMetadata[] = Reflect.getMetadata(EVENT_METADATA, controller.metatype)
 
         for (const handler of handlers) {
-          this.logger.log(`Mapped ${handler.callback.name} with event ${handler.eventName}`)
+          this.logger.log(`Mapped ${handler.callback.name} with queue ${handler.queueName}`)
 
           if (options.assertQueues === true) {
-            amqp.assertQueue(handler.eventName)
+            amqp.assertQueue(handler.queueName)
           }
 
           /**
@@ -59,9 +59,9 @@ export class AMQPModule implements OnModuleInit {
            * The default exchange is a direct exchange with no name (empty string) pre-declared by the broker
            * https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default
            */
-          amqp.bindQueue(handler.eventName, options?.exchange?.name || '', handler.eventName)
+          amqp.bindQueue(handler.queueName, options?.exchange?.name || '', handler.queueName)
 
-          amqp.consume(handler.eventName, async (msg) => {
+          amqp.consume(handler.queueName, async (msg) => {
             const f = await handler.callback(
               Buffer.isBuffer(msg?.content) ? msg?.content.toString() : msg?.content,
             )

--- a/lib/amqp.module.ts
+++ b/lib/amqp.module.ts
@@ -53,6 +53,14 @@ export class AMQPModule implements OnModuleInit {
             amqp.assertQueue(handler.eventName)
           }
 
+          /**
+           * bind queue to defined exchange in options, else bind to default exchange ('')
+           *
+           * The default exchange is a direct exchange with no name (empty string) pre-declared by the broker
+           * https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default
+           */
+          amqp.bindQueue(handler.eventName, options?.exchange?.name || '', handler.eventName)
+
           amqp.consume(handler.eventName, async (msg) => {
             const f = await handler.callback(
               Buffer.isBuffer(msg?.content) ? msg?.content.toString() : msg?.content,

--- a/lib/amqp.module.ts
+++ b/lib/amqp.module.ts
@@ -61,15 +61,20 @@ export class AMQPModule implements OnModuleInit {
            */
           amqp.bindQueue(handler.queueName, options?.exchange?.name || '', handler.queueName)
 
-          amqp.consume(handler.queueName, async (msg) => {
-            const f = await handler.callback(
-              Buffer.isBuffer(msg?.content) ? msg?.content.toString() : msg?.content,
-            )
+          amqp.consume(
+            handler.queueName,
+            async (msg) => {
+              const f = await handler.callback(
+                Buffer.isBuffer(msg?.content) ? msg?.content.toString() : msg?.content,
+              )
 
-            if (f !== false && msg) {
-              amqp.ack(msg)
-            }
-          })
+              // if noAck, the broker won’t expect an acknowledgement of messages delivered to this consumer
+              if (!handler.consumerOptions?.noAck && f !== false && msg) {
+                amqp.ack(msg)
+              }
+            },
+            handler.consumerOptions,
+          )
         }
       })
   }

--- a/lib/amqp.module.ts
+++ b/lib/amqp.module.ts
@@ -32,7 +32,9 @@ export class AMQPModule implements OnModuleInit {
       options: this.amqpService.getConnectionOptions(),
     }
 
-    if (options.exchange && options.exchange.assert) {
+    // what if exchange.assert = true and !type = true ????
+
+    if (options.exchange && options.exchange.assert && options.exchange.type) {
       amqp.assertExchange(options.exchange.name, options.exchange.type)
     }
 

--- a/lib/amqp.module.ts
+++ b/lib/amqp.module.ts
@@ -49,9 +49,8 @@ export class AMQPModule implements OnModuleInit {
         for (const handler of handlers) {
           this.logger.log(`Mapped ${handler.callback.name} with event ${handler.eventName}`)
 
-          amqp.assertQueue(handler.eventName)
-          if (options.exchange) {
-            amqp.bindQueue(handler.eventName, options.exchange.name, handler.eventName)
+          if (options.assertQueues === true) {
+            amqp.assertQueue(handler.eventName)
           }
 
           amqp.consume(handler.eventName, async (msg) => {

--- a/lib/amqp.service.ts
+++ b/lib/amqp.service.ts
@@ -22,7 +22,7 @@ export class AMQPService {
 
     const channel = this.amqpClient.clients.get(connectionName)
 
-    if(!channel) {
+    if (!channel) {
       throw new Error(`channel ${connectionName} does not exist`)
     }
 
@@ -40,7 +40,7 @@ export class AMQPService {
 
     const channel = this.amqpClient.clientOptions.get(connectionName)
 
-    if(!channel) {
+    if (!channel) {
       throw new Error(`channel ${connectionName} does not exist`)
     }
 

--- a/lib/decorators/subscribe-event.decorator.ts
+++ b/lib/decorators/subscribe-event.decorator.ts
@@ -1,7 +1,8 @@
+import { Options } from 'amqplib'
 import { EVENT_METADATA } from '../amqp.constants'
 import { EventMetadata } from '../amqp.interface'
 
-export const Consume = (queueName: string): MethodDecorator => {
+export const Consume = (queueName: string, consumerOptions?: Options.Consume): MethodDecorator => {
   return (target: object, key: string | symbol, descriptor: PropertyDescriptor) => {
     if (!Reflect.hasMetadata(EVENT_METADATA, target.constructor)) {
       Reflect.defineMetadata(EVENT_METADATA, [], target.constructor)
@@ -11,6 +12,7 @@ export const Consume = (queueName: string): MethodDecorator => {
 
     listeners.push({
       queueName,
+      consumerOptions,
       callback: descriptor.value,
     })
 

--- a/lib/decorators/subscribe-event.decorator.ts
+++ b/lib/decorators/subscribe-event.decorator.ts
@@ -1,7 +1,7 @@
 import { EVENT_METADATA } from '../amqp.constants'
 import { EventMetadata } from '../amqp.interface'
 
-export const Consume = (eventName: string): MethodDecorator => {
+export const Consume = (queueName: string): MethodDecorator => {
   return (target: object, key: string | symbol, descriptor: PropertyDescriptor) => {
     if (!Reflect.hasMetadata(EVENT_METADATA, target.constructor)) {
       Reflect.defineMetadata(EVENT_METADATA, [], target.constructor)
@@ -10,7 +10,7 @@ export const Consume = (eventName: string): MethodDecorator => {
     const listeners: EventMetadata[] = Reflect.getMetadata(EVENT_METADATA, target.constructor)
 
     listeners.push({
-      eventName,
+      queueName,
       callback: descriptor.value,
     })
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint \"lib/**/*.ts\"",
-    "build": "rimraf dist && tsc -p tsconfig.build.json",
+    "build": "rimraf dist && tsc -p tsconfig.build.json && tsc index.ts",
     "format": "prettier \"lib/**/*.ts\" --write",
     "prerelease": "npm run build",
     "release": "release-it",


### PR DESCRIPTION
Changelog:

- Added assertQueues option to the module options. This is in case you don't want @enriqcg/nestjs-amqp to assert the queues for you.
- Added assert to the Exchange interface on the module options. It doesn't assert the exchange unless explicitly defined.
- If no exchange is provided on the module options, use the default ('') exchange.
- **The entry point (index.js) was missing on the previous release**, rendering the package completely unusable. This is fixed now. The entry point is now compiled on every build.
- Added more options (same as amqplib) to the Consume decorator.
- Added .npmignore

Stuff to do before merging:
- [x] Update README.md showing the new parameters with examples